### PR TITLE
Allow interrupt on extraction

### DIFF
--- a/cancelable_reader.go
+++ b/cancelable_reader.go
@@ -1,0 +1,31 @@
+package extract
+
+import (
+	"errors"
+	"io"
+)
+
+func copyCancel(dst io.Writer, src io.Reader, cancel <-chan bool) (int64, error) {
+	return io.Copy(dst, newCancelableReader(src, cancel))
+}
+
+type cancelableReader struct {
+	cancel <-chan bool
+	src    io.Reader
+}
+
+func (r *cancelableReader) Read(p []byte) (int, error) {
+	select {
+	case <-r.cancel:
+		return 0, errors.New("interrupted")
+	default:
+		return r.src.Read(p)
+	}
+}
+
+func newCancelableReader(src io.Reader, cancel <-chan bool) *cancelableReader {
+	return &cancelableReader{
+		cancel: cancel,
+		src:    src,
+	}
+}

--- a/cancelable_reader_test.go
+++ b/cancelable_reader_test.go
@@ -1,0 +1,63 @@
+package extract
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCancelableReader(t *testing.T) {
+	var b [100000]byte
+	ctx, cancel := context.WithCancel(context.Background())
+	reader := newCancelableReader(ctx, bytes.NewReader(b[:]))
+	defer cancel()
+
+	var buff [1000]byte
+	readed := 0
+	for {
+		n, err := reader.Read(buff[:])
+		if err != nil {
+			fmt.Println("exit error:", err)
+			require.Equal(t, "EOF", err.Error())
+			break
+		}
+		require.NotZero(t, n)
+		time.Sleep(10 * time.Millisecond)
+		readed += n
+	}
+
+	fmt.Println("Readed", readed, "out of", len(b))
+	require.Equal(t, len(b), readed)
+}
+
+func TestCancelableReaderWithInterruption(t *testing.T) {
+	var b [100000]byte
+	ctx, cancel := context.WithCancel(context.Background())
+	reader := newCancelableReader(ctx, bytes.NewReader(b[:]))
+	defer cancel()
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	var buff [1000]byte
+	readed := 0
+	for {
+		n, err := reader.Read(buff[:])
+		if err != nil {
+			fmt.Println("exit error:", err)
+			require.Equal(t, "interrupted", err.Error())
+			break
+		}
+		require.NotZero(t, n)
+		time.Sleep(10 * time.Millisecond)
+		readed += n
+	}
+	fmt.Println("Readed", readed, "out of", len(b))
+	require.True(t, readed < len(b))
+}

--- a/extract_test.go
+++ b/extract_test.go
@@ -2,6 +2,7 @@ package extract_test
 
 import (
 	"bytes"
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -149,7 +150,7 @@ var ExtractCases = []struct {
 }
 
 func TestArchiveFailure(t *testing.T) {
-	err := extract.Archive(strings.NewReader("not an archive"), "", nil)
+	err := extract.Archive(context.Background(), strings.NewReader("not an archive"), "", nil)
 	if err == nil || err.Error() != "Not a supported archive" {
 		t.Error("Expected error 'Not a supported archive', got", err)
 	}
@@ -167,13 +168,13 @@ func TestExtract(t *testing.T) {
 
 		switch filepath.Ext(test.Archive) {
 		case ".bz2":
-			err = extract.Bz2(buffer, dir, test.Renamer)
+			err = extract.Bz2(context.Background(), buffer, dir, test.Renamer)
 		case ".gz":
-			err = extract.Gz(buffer, dir, test.Renamer)
+			err = extract.Gz(context.Background(), buffer, dir, test.Renamer)
 		case ".zip":
-			err = extract.Zip(buffer, dir, test.Renamer)
+			err = extract.Zip(context.Background(), buffer, dir, test.Renamer)
 		case ".mistery":
-			err = extract.Archive(buffer, dir, test.Renamer)
+			err = extract.Archive(context.Background(), buffer, dir, test.Renamer)
 		default:
 			t.Fatal("unknown error")
 		}
@@ -243,7 +244,7 @@ func BenchmarkArchive(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		buffer := bytes.NewBuffer(data)
-		err := extract.Archive(buffer, filepath.Join(dir, strconv.Itoa(i)), nil)
+		err := extract.Archive(context.Background(), buffer, filepath.Join(dir, strconv.Itoa(i)), nil)
 		if err != nil {
 			b.Error(err)
 		}
@@ -265,7 +266,7 @@ func BenchmarkTarBz2(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		buffer := bytes.NewBuffer(data)
-		err := extract.Bz2(buffer, filepath.Join(dir, strconv.Itoa(i)), nil)
+		err := extract.Bz2(context.Background(), buffer, filepath.Join(dir, strconv.Itoa(i)), nil)
 		if err != nil {
 			b.Error(err)
 		}
@@ -287,7 +288,7 @@ func BenchmarkTarGz(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		buffer := bytes.NewBuffer(data)
-		err := extract.Gz(buffer, filepath.Join(dir, strconv.Itoa(i)), nil)
+		err := extract.Gz(context.Background(), buffer, filepath.Join(dir, strconv.Itoa(i)), nil)
 		if err != nil {
 			b.Error(err)
 		}
@@ -309,7 +310,7 @@ func BenchmarkZip(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		buffer := bytes.NewBuffer(data)
-		err := extract.Zip(buffer, filepath.Join(dir, strconv.Itoa(i)), nil)
+		err := extract.Zip(context.Background(), buffer, filepath.Join(dir, strconv.Itoa(i)), nil)
 		if err != nil {
 			b.Error(err)
 		}


### PR DESCRIPTION
An optional `cancel` channel may now be passed to cancel the extraction. This turns out to be useful in case the operation needs to be interrupted by user request.
