### PR TITLE
Allow overwriting symlinks

### DIFF
--- a/extract.go
+++ b/extract.go
@@ -116,6 +116,7 @@ func Zip(ctx context.Context, body io.Reader, location string, rename Renamer) e
 type fs struct{}
 
 func (f fs) Link(oldname, newname string) error {
+	_ = os.Remove(newname) // Ignore error. We don't care if the file doesn't exist.
 	return os.Link(oldname, newname)
 }
 
@@ -124,6 +125,7 @@ func (f fs) MkdirAll(path string, perm os.FileMode) error {
 }
 
 func (f fs) Symlink(oldname, newname string) error {
+	_ = os.Remove(newname) // Ignore error. We don't care if the file doesn't exist.
 	return os.Symlink(oldname, newname)
 }
 


### PR DESCRIPTION
When extracting regular files, the file is opened for writing with `os.O_TRUNC`, making it suitable to extract over an existing file. This allows updating a local copy from an updated archive by extracting over it. If a link is added to the archive though, the second time it's extracted, an error occurs since `os.Link` and `os.Symlink` will not overwrite. This removes any file currently in place before attempting to write a link.