### PR TITLE
Add Remove to FS interface. Prepare for release v4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ type FS interface {
     MkdirAll(string, os.FileMode) error
     OpenFile(name string, flag int, perm os.FileMode) (*os.File, error)
     Symlink(string, string) error
+    Remove(path string) error
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/codeclysm/extract/master/LICENSE)
 [![Godoc Reference](https://img.shields.io/badge/Godoc-Reference-blue.svg)](https://godoc.org/github.com/codeclysm/extract)
 
-    import "github.com/codeclysm/extract/v3"
+    import "github.com/codeclysm/extract/v4"
 
 Package extract allows to extract archives in zip, tar.gz or tar.bz2 formats
 easily.

--- a/extract.go
+++ b/extract.go
@@ -92,7 +92,6 @@ func Zip(ctx context.Context, body io.Reader, location string, rename Renamer) e
 type fs struct{}
 
 func (f fs) Link(oldname, newname string) error {
-	_ = os.Remove(newname) // Ignore error. We don't care if the file doesn't exist.
 	return os.Link(oldname, newname)
 }
 
@@ -101,10 +100,13 @@ func (f fs) MkdirAll(path string, perm os.FileMode) error {
 }
 
 func (f fs) Symlink(oldname, newname string) error {
-	_ = os.Remove(newname) // Ignore error. We don't care if the file doesn't exist.
 	return os.Symlink(oldname, newname)
 }
 
 func (f fs) OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
 	return os.OpenFile(name, flag, perm)
+}
+
+func (f fs) Remove(path string) error {
+	return os.Remove(path)
 }

--- a/extract_test.go
+++ b/extract_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	"github.com/arduino/go-paths-helper"
-	"github.com/codeclysm/extract/v3"
+	"github.com/codeclysm/extract/v4"
 	"github.com/stretchr/testify/require"
 )
 

--- a/extract_test.go
+++ b/extract_test.go
@@ -222,43 +222,45 @@ func TestExtract(t *testing.T) {
 
 func TestExtractIdempotency(t *testing.T) {
 	for _, test := range ExtractCases {
-		dir, _ := os.MkdirTemp("", "")
-		dir = filepath.Join(dir, "test")
-		data, err := os.ReadFile(test.Archive)
-		if err != nil {
-			t.Fatal(err)
-		}
+		t.Run(test.Name, func(t *testing.T) {
+			dir, _ := os.MkdirTemp("", "")
+			dir = filepath.Join(dir, "test")
+			data, err := os.ReadFile(test.Archive)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		var extractFn func(context.Context, io.Reader, string, extract.Renamer) error
-		switch filepath.Ext(test.Archive) {
-		case ".bz2":
-			extractFn = extract.Bz2
-		case ".gz":
-			extractFn = extract.Gz
-		case ".zip":
-			extractFn = extract.Zip
-		case ".mistery":
-			extractFn = extract.Archive
-		default:
-			t.Fatal("unknown error")
-		}
+			var extractFn func(context.Context, io.Reader, string, extract.Renamer) error
+			switch filepath.Ext(test.Archive) {
+			case ".bz2":
+				extractFn = extract.Bz2
+			case ".gz":
+				extractFn = extract.Gz
+			case ".zip":
+				extractFn = extract.Zip
+			case ".mistery":
+				extractFn = extract.Archive
+			default:
+				t.Fatal("unknown error")
+			}
 
-		buffer := bytes.NewBuffer(data)
-		if err = extractFn(context.Background(), buffer, dir, test.Renamer); err != nil {
-			t.Fatal(test.Name, ": Should not fail first extraction: "+err.Error())
-		}
+			buffer := bytes.NewBuffer(data)
+			if err = extractFn(context.Background(), buffer, dir, test.Renamer); err != nil {
+				t.Fatal(test.Name, ": Should not fail first extraction: "+err.Error())
+			}
 
-		buffer = bytes.NewBuffer(data)
-		if err = extractFn(context.Background(), buffer, dir, test.Renamer); err != nil {
-			t.Fatal(test.Name, ": Should not fail second extraction: "+err.Error())
-		}
+			buffer = bytes.NewBuffer(data)
+			if err = extractFn(context.Background(), buffer, dir, test.Renamer); err != nil {
+				t.Fatal(test.Name, ": Should not fail second extraction: "+err.Error())
+			}
 
-		testWalk(t, dir, test.Files)
+			testWalk(t, dir, test.Files)
 
-		err = os.RemoveAll(dir)
-		if err != nil {
-			t.Fatal(err)
-		}
+			err = os.RemoveAll(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }
 

--- a/extractor_test.go
+++ b/extractor_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/arduino/go-paths-helper"
-	"github.com/codeclysm/extract/v3"
+	"github.com/codeclysm/extract/v4"
 	"github.com/stretchr/testify/require"
 )
 

--- a/extractor_test.go
+++ b/extractor_test.go
@@ -106,7 +106,6 @@ type MockDisk struct {
 func (m MockDisk) Link(oldname, newname string) error {
 	oldname = filepath.Join(m.Base, oldname)
 	newname = filepath.Join(m.Base, newname)
-	_ = os.Remove(newname)
 	return os.Link(oldname, newname)
 }
 
@@ -118,11 +117,14 @@ func (m MockDisk) MkdirAll(path string, perm os.FileMode) error {
 func (m MockDisk) Symlink(oldname, newname string) error {
 	oldname = filepath.Join(m.Base, oldname)
 	newname = filepath.Join(m.Base, newname)
-	_ = os.Remove(newname)
 	return os.Symlink(oldname, newname)
 }
 
 func (m MockDisk) OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
 	name = filepath.Join(m.Base, name)
 	return os.OpenFile(name, flag, perm)
+}
+
+func (m MockDisk) Remove(path string) error {
+	return os.Remove(filepath.Join(m.Base, path))
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/codeclysm/extract/v3
+module github.com/codeclysm/extract/v4
 
 go 1.22
 


### PR DESCRIPTION
After merging #26 I noticed this is a breaking change for users relying on the `Extractor.FS` interface. 

They should change their implementation to conform to the new definition of Link and Symlink (which now requires overwriting the `newpath` target). Let's make the breaking change explicit and add the `Remove` method to the interface.

This also allows other changes that are coming soon.

