### PR TITLE
v5: change FS interface to have OpenFile() return an io.WriteCloser

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/codeclysm/extract/master/LICENSE)
 [![Godoc Reference](https://img.shields.io/badge/Godoc-Reference-blue.svg)](https://godoc.org/github.com/codeclysm/extract)
 
-    import "github.com/codeclysm/extract/v4"
+    import "github.com/codeclysm/extract/v5"
 
 Package extract allows to extract archives in zip, tar.gz or tar.bz2 formats
 easily.

--- a/extract.go
+++ b/extract.go
@@ -103,7 +103,7 @@ func (f fs) Symlink(oldname, newname string) error {
 	return os.Symlink(oldname, newname)
 }
 
-func (f fs) OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
+func (f fs) OpenFile(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
 	return os.OpenFile(name, flag, perm)
 }
 

--- a/extract_test.go
+++ b/extract_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	"github.com/arduino/go-paths-helper"
-	"github.com/codeclysm/extract/v4"
+	"github.com/codeclysm/extract/v5"
 	"github.com/stretchr/testify/require"
 )
 

--- a/extractor.go
+++ b/extractor.go
@@ -31,7 +31,7 @@ type Extractor struct {
 		MkdirAll(path string, perm os.FileMode) error
 
 		// OpenFile opens the named file with specified flag (O_RDONLY etc.).
-		OpenFile(name string, flag int, perm os.FileMode) (*os.File, error)
+		OpenFile(name string, flag int, perm os.FileMode) (io.WriteCloser, error)
 
 		// Symlink creates newname as a symbolic link to oldname.
 		Symlink(oldname, newname string) error

--- a/extractor_test.go
+++ b/extractor_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -14,7 +15,7 @@ import (
 	"testing"
 
 	"github.com/arduino/go-paths-helper"
-	"github.com/codeclysm/extract/v4"
+	"github.com/codeclysm/extract/v5"
 	"github.com/stretchr/testify/require"
 )
 
@@ -351,7 +352,7 @@ func (m MockDisk) Symlink(oldname, newname string) error {
 	return os.Symlink(oldname, newname)
 }
 
-func (m MockDisk) OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
+func (m MockDisk) OpenFile(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
 	name = filepath.Join(m.Base, name)
 	return os.OpenFile(name, flag, perm)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/codeclysm/extract/v4
+module github.com/codeclysm/extract/v5
 
 go 1.22
 

--- a/loggingfs_test.go
+++ b/loggingfs_test.go
@@ -2,6 +2,7 @@ package extract_test
 
 import (
 	"fmt"
+	"io"
 	"os"
 )
 
@@ -88,7 +89,7 @@ func (m *LoggingFS) Symlink(oldname, newname string) error {
 	return err
 }
 
-func (m *LoggingFS) OpenFile(name string, flags int, perm os.FileMode) (*os.File, error) {
+func (m *LoggingFS) OpenFile(name string, flags int, perm os.FileMode) (io.WriteCloser, error) {
 	f, err := os.OpenFile(name, flags, perm)
 	op := &LoggedOp{
 		Op:    "open",


### PR DESCRIPTION
A small change that is unfortunately API breaking (hence `v5`). Addresses #29 and probably also enables a solution for #25.